### PR TITLE
Use web client token to create unity token 

### DIFF
--- a/pkg/client/unity/main.go
+++ b/pkg/client/unity/main.go
@@ -45,7 +45,7 @@ func generateClaim(accountId string, sandboxId string, characterId string) *Clai
 }
 
 func loadPrivateKey() *rsa.PrivateKey {
-	privateKeyFile := "./keys/unity-client.pem"
+	privateKeyFile := "./keys/unity-client-private.pem"
 	privateKeyBytes, err := ioutil.ReadFile(privateKeyFile)
 	if err != nil {
 		fmt.Println("Error reading private key: ", err)


### PR DESCRIPTION
Previous had to pass accountId, sandboxId, and characterId from the web app to generate a token which was not very good. 

Now, the web app token is passed with a characterId in the  payload. 