### PR TITLE
Added /accounts GET endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func registerMuxHandlers(app *core.App) http.Handler {
 	app.Router.HandleFunc("/my/characters", characters.GetMyCharacters(app)).Methods("GET")
 
 	// Accounts
+	app.Router.HandleFunc("/accounts", accounts.GetAccounts(app)).Methods("GET")
 	app.Router.HandleFunc("/accounts", accounts.CreateAccount(app)).Methods("POST")
 	app.Router.HandleFunc("/accounts/{id}", accounts.GetAccountById(app)).Methods("GET")
 	app.Router.HandleFunc("/accounts/{id}", accounts.UpdateAccount(app)).Methods("PATCH")

--- a/pkg/accounts/handlers/GetAccounts.go
+++ b/pkg/accounts/handlers/GetAccounts.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	models "github.com/maxfelker/terra-major-api/pkg/accounts/models"
+	"github.com/maxfelker/terra-major-api/pkg/core"
+	"github.com/maxfelker/terra-major-api/pkg/utils"
+)
+
+func GetAccounts(app *core.App) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		email := request.URL.Query().Get("email")
+
+		var accounts []models.Account
+		query := app.DB
+
+		if email != "" {
+			query = query.Where("email LIKE ?", "%"+strings.TrimSpace(email)+"%")
+		}
+
+		result := query.Find(&accounts)
+		if result.Error != nil {
+			utils.ReturnError(writer, result.Error.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var baseAccounts []models.BaseAccount
+		for _, account := range accounts {
+			baseAccounts = append(baseAccounts, models.BaseAccount{
+				ID:      account.ID,
+				Email:   account.Email,
+				Created: account.Created,
+				Updated: account.Updated,
+			})
+		}
+
+		response, err := json.Marshal(baseAccounts)
+
+		if err != nil {
+			utils.ReturnError(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		writer.Write(response)
+	}
+}


### PR DESCRIPTION
When a requesting system hits the follow endpoint:

> GET /accounts

It will return an array of account objects like so:

```json
[
    {
        "id": "5185c3aa-019b-4246-a83a-e53f0b16d189",
        "email": "max@maxfelker.com",
        "created": "2024-01-20T17:12:11.335895Z",
        "updated": "2024-01-20T17:12:11.335895Z"
    },
    {
        "id": "748f6399-4250-437c-a9b2-e28d24ca2fbb",
        "email": "test@max.com",
        "created": "2024-02-12T23:23:01.265138Z",
        "updated": "2024-02-12T23:23:01.265138Z"
    },
    {
        "id": "d5f2172c-35f9-4c6b-962d-b20b37d85d04",
        "email": "world@world.com",
        "created": "2024-06-25T07:39:31.998322Z",
        "updated": "2024-06-25T07:39:31.998322Z"
    }
]
```

You can reduce the list by using the `?email=` query parameter. 