### PR TITLE
Fixing null response from /accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Persistence cloud API to store locations of objects in Unity 3D space.
 First, create a `.env` file in the root of the directory with the following values:
 
 ```bash
-ALLOWED_ORIGINS=http://localhost:5173,https://localhost:5173,http://localhost,https://localhost
+ALLOWED_ORIGINS=http://localhost:5173,https://localhost:5173,http://localhost:5174,https://localhost:5174,http://localhost,https://localhost
 
 POSTGRES_HOST=postgres
 POSTGRES_USER=tmdbuser

--- a/pkg/accounts/handlers/GetAccounts.go
+++ b/pkg/accounts/handlers/GetAccounts.go
@@ -27,7 +27,7 @@ func GetAccounts(app *core.App) http.HandlerFunc {
 			return
 		}
 
-		var baseAccounts []models.BaseAccount
+		baseAccounts := []models.BaseAccount{}
 		for _, account := range accounts {
 			baseAccounts = append(baseAccounts, models.BaseAccount{
 				ID:      account.ID,


### PR DESCRIPTION
When the API found 0 accounts, it was returning `null` vs an empty array which caused the new admin to fail on load. Now, /accounts will return an empty array if 0 accounts are found.

Also updated the readme to include http://localhost:5174 which is the port for the new admin.